### PR TITLE
chore: bump to lts-22.3

### DIFF
--- a/haskchimp.cabal
+++ b/haskchimp.cabal
@@ -20,7 +20,7 @@ source-repository head
   location:            https://github.com/dariooddenino/haskchimp.git
 
 common common-options
-  build-depends:       base ^>= 4.16.4.0
+  build-depends:       base >= 4.16.4.0 && < 5
                      , aeson
                      , bytestring
                      , http-conduit

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-20.5
+resolver: lts-22.3


### PR DESCRIPTION
This bumps livtours/haskchimp package lts and relaxes constraints on `base`